### PR TITLE
A different attempt at setting tx power

### DIFF
--- a/fcc.js
+++ b/fcc.js
@@ -49,7 +49,7 @@ function allSteps (emitter, listener) {
   }
 
   if (parseInt(channel) > 11 && txpower) {
-    var TXPOWER = 'iw mon0 set txpower fixed ' + txpower + '00';
+    var TXPOWER = 'iw dev wlan0 set txpower fixed' + txpower + '00';
   } else {
     var TXPOWER = '';
   }


### PR DESCRIPTION
When I ran the previous command on my Tessel (`iw mon0 set txpower fixed 2000`) the usage instructions for `iw` were printed out. I may have a different wireless config though - I'm not aware of what how the configuration setup might be different.
